### PR TITLE
introduce HTTPX_CA_BUNDLE, fix docs

### DIFF
--- a/docs/advanced/ssl.md
+++ b/docs/advanced/ssl.md
@@ -69,21 +69,11 @@ ctx.load_cert_chain(certfile="path/to/client.pem")  # Optionally also keyfile or
 client = httpx.Client(verify=ctx)
 ```
 
-### Working with `SSL_CERT_FILE` and `SSL_CERT_DIR`
+### Providing CA from environment
 
-Unlike `requests`, the `httpx` package does not automatically pull in [the environment variables `SSL_CERT_FILE` or `SSL_CERT_DIR`](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_default_verify_paths.html). If you want to use these they need to be enabled explicitly.
+`httpx` package automatically pulls in [the environment variables `SSL_CERT_FILE` or `SSL_CERT_DIR`](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_default_verify_paths.html) untill trust_env is `True`.
 
-For example...
-
-```python
-# Use `SSL_CERT_FILE` or `SSL_CERT_DIR` if configured.
-# Otherwise default to certifi.
-ctx = ssl.create_default_context(
-    cafile=os.environ.get("SSL_CERT_FILE", certifi.where()),
-    capath=os.environ.get("SSL_CERT_DIR"),
-)
-client = httpx.Client(verify=ctx)
-```
+Alternatively you can use `HTTPX_CA_BUNDLE` env which acts as `SSL_CERT_FILE`.
 
 ### Making HTTPS requests to a local server
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -51,3 +51,9 @@ python -c "import httpx; httpx.get('http://example.com')"
 python -c "import httpx; httpx.get('http://127.0.0.1:5000/my-api')"
 python -c "import httpx; httpx.get('https://www.python-httpx.org')"
 ```
+
+
+## TLS
+
+### `HTTPX_CA_BUNDLE`
+Overrides default `certifi` trust store

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -33,6 +33,8 @@ def create_ssl_context(
     if verify is True:
         if trust_env and os.environ.get("SSL_CERT_FILE"):  # pragma: nocover
             ctx = ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])
+        elif trust_env and os.environ.get("HTTPX_CA_BUNDLE"):  # pragma: nocover
+            ctx = ssl.create_default_context(cafile=os.environ["HTTPX_CA_BUNDLE"])
         elif trust_env and os.environ.get("SSL_CERT_DIR"):  # pragma: nocover
             ctx = ssl.create_default_context(capath=os.environ["SSL_CERT_DIR"])
         else:


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
<!-- Write a small summary about what is happening here. -->
`HTTPX_CA_BUNDLE` env-variable was introduced (similar to REQUESTS_CA_BUNDLE). The motivation behind it: `SSL_CERT_FILE` affects other libraries/programs. Alternatively I can introduce `HTTPX_SYSTEM_CA`.

Related to #302

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.
